### PR TITLE
Fix Dockerfile parse error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,10 +7,9 @@ ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="3.23"
  # Optionally install the cmake for vcpkg
 COPY ./reinstall-cmake.sh /tmp/
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive 
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends clang-format
 
 # Obtain vcpkg repository and set VCPKG_ROOT
 RUN git clone --depth 1 https://github.com/microsoft/vcpkg /vcpkg
 ENV VCPKG_ROOT="/vcpkg"
-


### PR DESCRIPTION
Correct the `RUN` command in the `.devcontainer/Dockerfile` to properly install `clang-format`.

* Replace `&&` with `\` to continue the command on the next line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GengGode/cvat/pull/2?shareId=737f3f29-5f83-4bca-b4ec-8ceeb7f8f934).